### PR TITLE
解决开发环境下“未找到任何配置文件”误报问题

### DIFF
--- a/cli/go.py
+++ b/cli/go.py
@@ -17,7 +17,7 @@ import retry
 from loguru import logger
 from requests import HTTPError, RequestException
 
-from config import main_request, configDB, time_service
+from config import main_request, configDB, time_service, get_application_path
 from tool import PushPlus
 from tool import ServerChan
 from tool.error import ERRNO_DICT
@@ -56,7 +56,7 @@ def generate_qr_code(qr_data):
 def go_cli():
     isRunning = True
     
-    base_dir = os.path.dirname(os.path.realpath(sys.executable))
+    base_dir = get_application_path()
     config_dir = os.path.join(base_dir, "configs")
     os.makedirs(config_dir, exist_ok=True)
     config_files = [f for f in os.listdir(config_dir) if f.endswith('.json') and f not in {'config.json', 'cookies.json','machine_config.json'}]


### PR DESCRIPTION
修复了配置文件无法识别的问题。原先 config_dir 路径获取方式统一为 get_application_path()，确保无论在开发环境还是打包环境下都能正确读取 configs 目录下的配置文件，解决“未找到任何配置文件”误报的问题。